### PR TITLE
Better front matter support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docbook",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,6 +24,14 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1074,6 +1082,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1112,6 +1125,14 @@
       "optional": true,
       "requires": {
         "fill-range": "2.2.4"
+      }
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "requires": {
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -1767,6 +1788,24 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "gray-matter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.1.tgz",
+      "integrity": "sha512-p0MADBEBl1CohV7nRZ8sVinBexEe3CKVhh0A0QIHKpcbRoxB0VgeMpRPjW/HBHIPLAKrpIIIm5mZ6hKu3E+iQg==",
+      "requires": {
+        "js-yaml": "3.12.0",
+        "kind-of": "6.0.2",
+        "section-matter": "1.0.0",
+        "strip-bom-string": "1.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1871,9 +1910,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -1959,6 +1996,15 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
     },
     "jsesc": {
       "version": "1.3.0",
@@ -2471,6 +2517,22 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -2529,6 +2591,11 @@
         "source-map": "0.5.7"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2570,6 +2637,11 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "clean-css": "^4.1.11",
     "dom-parser": "^0.1.5",
+    "gray-matter": "^4.0.1",
     "html-minifier": "^3.5.16",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",

--- a/src/core/functions/content.js
+++ b/src/core/functions/content.js
@@ -8,15 +8,25 @@ export default function(data) {
   let index = '';
   let matches = [];
 
-  while ((matches = regex.exec(data.html)) !== null) {
-    index += `<div${matches[1] === '3' ? ' class="indent"' : ''}>
-    <a href="#${matches[2]}">${matches[3]}</a>
-    </div>`;
-  }
+  const option = data.frontMatter.contents.toLowerCase();
 
-  // This does the check if index of the page, must be shown or not
-  if (index)
-    index = '<div>Contents</div>' + index;
+  /**
+   * Contents is disabled for the page
+   */
+  if (option !== 'disable') {
+    while ((matches = regex.exec(data.html)) !== null) {
+
+      if (option === 'simple' && matches[1] === '3') continue;
+      
+      index += `<div${matches[1] === '3' ? ' class="indent"' : ''}>
+      <a href="#${matches[2]}">${matches[3]}</a>
+      </div>`;
+    }
+
+    // This does the check if index of the page, must be shown or not
+    if (index)
+      index = '<div>Contents</div>' + index;
+  }
 
   return data.html.replace('{{ index }}', index);
 }

--- a/src/core/functions/content.js
+++ b/src/core/functions/content.js
@@ -8,7 +8,7 @@ export default function(data) {
   let index = '';
   let matches = [];
 
-  while ((matches = regex.exec(data)) !== null) {
+  while ((matches = regex.exec(data.html)) !== null) {
     index += `<div${matches[1] === '3' ? ' class="indent"' : ''}>
     <a href="#${matches[2]}">${matches[3]}</a>
     </div>`;
@@ -18,5 +18,5 @@ export default function(data) {
   if (index)
     index = '<div>Contents</div>' + index;
 
-  return data.replace('{{ index }}', index);
+  return data.html.replace('{{ index }}', index);
 }

--- a/src/core/functions/createHTML.js
+++ b/src/core/functions/createHTML.js
@@ -20,10 +20,10 @@ export default function(path, data, options, callback) {
      * being converted too
      */
     if (options.to && options.to === '.html') {
-      const htmlTemplate = templateHTML(data.meta);
+      const htmlTemplate = templateHTML(data.frontMatter);
 
       // Merge the data into the template
-      data = htmlTemplate.replace('{{ content }}', data.html);
+      data.html = htmlTemplate.replace('{{ content }}', data.html);
     }
 
     // Additional plugins that are being used are injected here

--- a/src/core/functions/createHTML.js
+++ b/src/core/functions/createHTML.js
@@ -4,6 +4,7 @@ import mkdirp from 'mkdirp';
 import { minify } from "html-minifier";
 
 import templateHTML from './templates/html';
+import indexGen from './templates/html/content';
 import injectPlugins from './plugins/parser';
 
 /**
@@ -26,8 +27,11 @@ export default function(path, data, options, callback) {
       data.html = htmlTemplate.replace('{{ content }}', data.html);
     }
 
-    // Additional plugins that are being used are injected here
-    data = injectPlugins(data);
+    // Additional plugins that are being used are injected
+    data.html = injectPlugins(data);
+
+    // Contents sidebar is added
+    data = indexGen(data);
 
     // Minify the html
     data = minify(data, {

--- a/src/core/functions/plugins/parser.js
+++ b/src/core/functions/plugins/parser.js
@@ -9,7 +9,7 @@ export default function(data) {
 
   if (plugins && typeof plugins === 'object') {
     const parser = new domParser();
-    const dom = parser.parseFromString(data);
+    const dom = parser.parseFromString(data.html);
 
     Object.keys(plugins).forEach(tag => {
       dom.getElementsByTagName(tag).forEach(element => {
@@ -18,7 +18,7 @@ export default function(data) {
         /**
          * Replace the component content with plugin content after it is loaded
          */
-        data = data.replace(element.outerHTML, plugin);
+        data.html = data.html.replace(element.outerHTML, plugin);
       });
     })
   }

--- a/src/core/functions/plugins/parser.js
+++ b/src/core/functions/plugins/parser.js
@@ -1,11 +1,9 @@
 import domParser from 'dom-parser';
 import pluginLoader from './loader';
-import indexGen from '../content';
 
 export default function(data) {
   const config = require(__base + '/docbook.config');
   const plugins = config.plugins;
-
 
   if (plugins && typeof plugins === 'object') {
     const parser = new domParser();
@@ -16,13 +14,13 @@ export default function(data) {
         const plugin = pluginLoader(`${__base}/${plugins[tag]}`, element);
         
         /**
-         * Replace the component content with plugin content after it is loaded
+         * Replace the component content with plugin content after it is
+         * loaded. Styles are appened separately
          */
         data.html = data.html.replace(element.outerHTML, plugin);
       });
     })
   }
 
-  // Contents sidebar will be generated and returned
-  return indexGen(data);
+  return data.html;
 }

--- a/src/core/functions/templates/html.js
+++ b/src/core/functions/templates/html.js
@@ -5,6 +5,7 @@ import addAttributes from '../../utils/attributes';
 export default function(frontMatter) {
   const config = require(__base+'/docbook.config');
 
+  // Gets the HTML template
   let template = '';
   template = fs.readFileSync(path.join(__dirname, '../../templates/html.html')).toString();
 
@@ -12,10 +13,6 @@ export default function(frontMatter) {
   if (frontMatter.lang)
     template = template.replace('lang="en"', `lang="${frontMatter.lang}"`);
 
-  /**
-   * 'meta', 'link' data is taken from the config file and added to the
-   * html template
-   */
 
   // If title is present in meta data for the page, then use it
   if (frontMatter.title)
@@ -31,9 +28,19 @@ export default function(frontMatter) {
    * Adds the theme-color meta tag if themeColor was added in the config file
    * before adding meta tags defined in the config file
    */
-  let tags = config.themeColor ? `<meta name="theme-color" content="${config.themeColor}">` : '';
-  if (Array.isArray(config.head.meta)) {
-    config.head.meta.forEach(metaInfo => {
+  let tags = config.themeColor ?
+  `<meta name="theme-color" content="${config.themeColor}">` : '';
+
+  /**
+   * Creates the <head> section of the site
+   */
+  if (config.head && typeof config.head === 'object') {
+    Object.keys(config.head).forEach(tag => {
+      // If the property is not of Array type
+      if (!Array.isArray(config.head[tag])) return;
+
+      if (tag === 'meta') {
+        return config.head.meta.forEach(metaInfo => {
 
       // Page meta data overrides the global meta data
       if (frontMatter.meta) {
@@ -42,7 +49,12 @@ export default function(frontMatter) {
           delete frontMatter.meta[metaInfo.name];
       }
 
-      tags += addAttributes('meta', metaInfo)+'\n'
+          tags += addAttributes('meta', metaInfo);
+        });
+      }
+
+      config.head[tag].forEach(tagInfo => tags += addAttributes(tag, tagInfo));
+
     });
   }
 
@@ -52,23 +64,21 @@ export default function(frontMatter) {
       tags += addAttributes('meta', {
         name: metaName,
         content: frontMatter.meta[metaName]
-      })+'\n';
+      });
     }
   }
-  template = template.replace('{{ meta }}', tags);
-
-  // Link tags
-  tags = '';
-  if (Array.isArray(config.head.link))
-    config.head.link.forEach(linkInfo => tags += addAttributes('link', linkInfo)+'\n');
-
-  template = template.replace('{{ link }}', tags);
+  // Injects the head tags in the template
+  template = template.replace('{{ head }}', tags);
 
 
   // Header
   if (config.navigation || config.logo) {
     template = template.replace('{{ header }}',
-      `<header>${config.logo ? `<a href="/" class="brand"><img alt="${config.head ? config.head.title : 'Docbook site'}" src=${config.logo}></a>` : ''}<nav>{{ nav }}</nav></header>`
+      `<header>${config.logo ?
+      `<a href="/" class="brand"><img alt="${config.head ?
+      config.head.title :
+      'Docbook site'}" src=${config.logo}></a>` :
+      ''}<nav>{{ nav }}</nav></header>`
     );
     // Adds a class to the container to accomodate for the fixed header height
     template = template.replace('<div class="container">', '<div class="container fixed-head">');
@@ -106,9 +116,9 @@ export default function(frontMatter) {
   template = template.replace('{{ nav }}', tags);
 
   // Scripts for the body section
-  tags = '<script src="/script.js"></script>\n';
+  tags = '<script src="/script.js"></script>';
   if (Array.isArray(config.scripts))
-    config.scripts.forEach(scriptInfo => tags += addAttributes('script', scriptInfo)+'</script>\n');
+    config.scripts.forEach(scriptInfo => tags += addAttributes('script', scriptInfo)+'</script>');
 
   template = template.replace('{{ body }}', tags);
 

--- a/src/core/functions/templates/html/content.js
+++ b/src/core/functions/templates/html/content.js
@@ -7,8 +7,8 @@ const regex = /<h([2-3]) id="(.*?)".*?><a.*?>(.*?)<\/a><\/h[2-3]/g;
 export default function(data) {
   let index = '';
   let matches = [];
-
-  const option = data.frontMatter.contents.toLowerCase();
+  let option = data.frontMatter.contents;
+  option = typeof option === 'string' ? option.toLowerCase() : 'dense';
 
   /**
    * Contents is disabled for the page
@@ -27,6 +27,7 @@ export default function(data) {
     if (index)
       index = '<div>Contents</div>' + index;
   }
+
 
   return data.html.replace('{{ index }}', index);
 }

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -125,7 +125,7 @@ export default function(frontMatter) {
 
   // Sidebar
   tags = '';
-  if (config.sidebar && typeof config.sidebar === 'object') {
+  if (config.sidebar && typeof config.sidebar === 'object' && frontMatter.sidebar != 'disable') {
     for (let name in config.sidebar) {
       const val = config.sidebar[name];
 

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import addAttributes from '../../utils/attributes';
+import addAttributes from '../../../utils/attributes';
 
 export default function(frontMatter) {
   const config = require(__base+'/docbook.config');
 
   // Gets the HTML template
   let template = '';
-  template = fs.readFileSync(path.join(__dirname, '../../templates/html.html')).toString();
+  template = fs.readFileSync(path.join(__dirname, '../../../templates/html.html')).toString();
 
   // lang of the page is set here
   if (frontMatter.lang)

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -72,7 +72,7 @@ export default function(frontMatter) {
 
 
   // Header
-  if (config.navigation || config.logo) {
+  if ((config.navigation || config.logo) && frontMatter.header != 'disable') {
     template = template.replace('{{ header }}',
       `<header>${config.logo ?
       `<a href="/" class="brand"><img alt="${config.head ?

--- a/src/core/templates/html.html
+++ b/src/core/templates/html.html
@@ -4,12 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  {{ meta }}
   <title>{{ title }}</title>
 
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
-  {{ link }}
+  {{ head }}
 </head>
 <body>
   <a class="skip-link" href="#content">Skip to content</a>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import showdown from 'showdown';
+import matter from 'gray-matter';
 
 import recursiveRead from './core/functions/recurRead';
 import createHTML from './core/functions/createHTML';
@@ -14,18 +15,17 @@ const dir = 'src/';
 /**
  * Showdown extension that is used to make h1, h2, h3 elements anchored links
  */
-showdown.extension('heading-anchor', function() {
-  return [{
+showdown.extension('heading-anchor', () =>
+  [{
     type: 'html',
     regex: /(<h([1-3]) id="([^"]+?)">)(.*)(<\/h\2>)/g,
     replace: '$1<a class="anchor" href="#$3" aria-hidden="true" tabindex="-1">$4</a>$5'
-  }];
-});
+  }]
+);
 
 const converter = new showdown.Converter({
   ghCompatibleHeaderId: true,
   extensions: ['heading-anchor'],
-  metadata: true,
   emoji: true
 });
 
@@ -60,12 +60,12 @@ export default function() {
         const file = Buffer.from(fileBuf);
         const markdown = file.toString();
     
-        const html = converter.makeHtml(markdown);
-        const metaData = converter.getMetadata();
+        const content = matter(markdown);
+        const html = converter.makeHtml(content.content);
     
         const fullPath = path.join(__base, 'dist', filePath.replace(dir, ''));
         
-        createHTML(fullPath, {html, meta: metaData}, { to: '.html' }, err => {
+        createHTML(fullPath, {html, frontMatter: content.data}, { to: '.html' }, err => {
           console.log(err);
         });
 


### PR DESCRIPTION
**Better front matter** support is added. Previously, only `<meta>` tags were allowed, but now based on **YAML**, other data can also be added in the front matter. Options that are implemented in this PR:

- title: `Page title`
- meta
    - name: content
- contents: `simple | dense | disable`
- sidebar: `disable | enable`
- header: `disable | enable`

Additional modes, options to different parts of the page can be easily extended. 

`head` in the config file now **supports all tags**, based on the new system that works with all properties in the `head` object.