### PR TITLE
Added support for drop menus

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "es2015",
     "minify"
   ],
+  "plugins": ["transform-object-rest-spread"],
   "ignore": [
     "./node_modules",
     "./.babelrc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docbook",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -461,6 +461,12 @@
         "babel-helper-is-void-0": "0.4.3"
       }
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
@@ -718,6 +724,16 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
       "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-minify": "^0.4.3",
     "clean-css-cli": "^4.1.11"

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -28,9 +28,9 @@ function navCreator(nav, type, recurLevel = 1) {
          * Drop down menu is setup
          */
         return tags += `<span tabindex="0">${name}
-          <i class="icon ion-ios-arrow-down"></i>
+          <i class="icon ion-ios-arrow-${type === 'footer' ? 'up' : 'down'}"></i>
           <div class="drop-menu">
-            ${navCreator(val, null, ++recurLevel)}
+            ${navCreator(val, 'sub', ++recurLevel)}
           </div>
           </span>`;
       }
@@ -197,7 +197,7 @@ export default function(frontMatter) {
 
 
   // Footer
-  template = template.replace('{{ footer }}', navCreator(config.footer));
+  template = template.replace('{{ footer }}', navCreator(config.footer, 'footer'));
 
   return template;
 }

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import addAttributes from '../../../utils/attributes';
 
-function navCreator(nav, type) {
+function navCreator(nav, type, recurLevel = 1) {
   let tags = '';
 
   if (Array.isArray(nav)) {
@@ -18,13 +18,24 @@ function navCreator(nav, type) {
       else if (!val) {
         tags += `<span>${name}</span>`;
       }
+      else if (Array.isArray(val) && recurLevel < 3) {
+        /**
+         * Drop down menu is setup
+         */
+        tags += `<span tabindex="0">${name}
+          <i class="icon ion-ios-arrow-down"></i>
+          <div class="drop-menu">
+            ${navCreator(val, null, ++recurLevel)}
+          </div>
+          </span>`;
+      }
       else if (typeof val === 'object') {
-        // If the link is supposed to open in a new tab
+        /**
+         * If the link is supposed to open in a new tab
+         */
         tags += addAttributes('a', {
           href: val.link, target: val.newTab ? '_blank' : ''
         }) + name+'</a>';
-
-        // TODO: Implement dropdown menu
       }
     }
   }

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -6,38 +6,45 @@ function navCreator(nav, type, recurLevel = 1) {
   let tags = '';
 
   if (Array.isArray(nav)) {
-    for (let item of nav) {
+    nav.forEach(item => {
+
+      if (typeof item === 'string')
+        return tags += `<span>${item}</span>`;
+
       const name = item[0];
       const val = item[1];
 
       if (typeof val === 'string') {
-        tags += addAttributes('a', {
+        return tags += addAttributes('a', {
           href: val
         }) + name+'</a>';
       }
-      else if (!val) {
-        tags += `<span>${name}</span>`;
-      }
-      else if (Array.isArray(val) && recurLevel < 3) {
+
+      if (!val)
+        return tags += `<span>${name}</span>`;
+
+      if (Array.isArray(val) && recurLevel < 3) {
         /**
          * Drop down menu is setup
          */
-        tags += `<span tabindex="0">${name}
+        return tags += `<span tabindex="0">${name}
           <i class="icon ion-ios-arrow-down"></i>
           <div class="drop-menu">
             ${navCreator(val, null, ++recurLevel)}
           </div>
           </span>`;
       }
-      else if (typeof val === 'object') {
+
+      if (typeof val === 'object') {
         /**
          * If the link is supposed to open in a new tab
          */
-        tags += addAttributes('a', {
+        return tags += addAttributes('a', {
           href: val.link, target: val.newTab ? '_blank' : ''
         }) + name+'</a>';
       }
-    }
+
+    });
   }
 
   return tags;

--- a/src/core/templates/css/dark.css
+++ b/src/core/templates/css/dark.css
@@ -36,7 +36,7 @@ body.dark {
   background-color: #191F24;
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.36);
 }
-.dark header nav span div.drop-menu {
+.dark span div.drop-menu {
   background-color: #191F24;
   border-color: #4d5a60;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.36);

--- a/src/core/templates/css/dark.css
+++ b/src/core/templates/css/dark.css
@@ -36,6 +36,11 @@ body.dark {
   background-color: #191F24;
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.36);
 }
+.dark header nav span div.drop-menu {
+  background-color: #191F24;
+  border-color: #4d5a60;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.36);
+}
 
 .dark .sidebar {
   background-color: #111418;

--- a/src/core/templates/css/styles.css
+++ b/src/core/templates/css/styles.css
@@ -168,10 +168,44 @@ header nav button.theme-toggle {
 header nav button.theme-toggle:hover {
   background-color: rgba(0, 0, 0, 0.1);
 }
+header nav a, header nav span {
+  height: 60px;
+  display: flex;
+  align-items: center;
+}
 header nav a, header nav span,
 footer a, footer span {
   padding: 0 10px;
   font-weight: 600;
+}
+header nav span {
+  position: relative;
+}
+header nav span .ion-ios-arrow-down {
+  margin-left: 5px;
+  font-size: 16px;
+}
+header nav span:hover div.drop-menu,
+header nav span:focus div.drop-menu {
+  display: block;
+}
+header nav span div.drop-menu {
+  display: none;
+  position: absolute;
+  top: 60px;
+  right: 0;
+  min-width: 100px;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid #E1E8E8;
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(30, 38, 36, .12);
+}
+header nav span div.drop-menu span,
+header nav span div.drop-menu a {
+  padding: 10px 15px;
+  display: block;
+  height: auto;
 }
 
 footer {

--- a/src/core/templates/css/styles.css
+++ b/src/core/templates/css/styles.css
@@ -182,15 +182,18 @@ header nav span {
   position: relative;
 }
 header nav span .ion-ios-arrow-down {
-  margin-left: 5px;
-  font-size: 16px;
+  margin-left: 8px;
+  font-size: 12px;
 }
 header nav span:hover div.drop-menu,
 header nav span:focus div.drop-menu {
-  display: block;
+  visibility: visible;
+  opacity: 1;
 }
 header nav span div.drop-menu {
-  display: none;
+  opacity: 0;
+  visibility: hidden;
+
   position: absolute;
   top: 60px;
   right: 0;
@@ -200,6 +203,7 @@ header nav span div.drop-menu {
   border: 1px solid #E1E8E8;
   border-radius: 3px;
   box-shadow: 0 3px 8px rgba(30, 38, 36, .12);
+  transition: all 0.2s ease;
 }
 header nav span div.drop-menu span,
 header nav span div.drop-menu a {

--- a/src/core/templates/css/styles.css
+++ b/src/core/templates/css/styles.css
@@ -170,7 +170,7 @@ header nav button.theme-toggle:hover {
 }
 header nav a, header nav span {
   height: 60px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
 }
 header nav a, header nav span,
@@ -178,19 +178,20 @@ footer a, footer span {
   padding: 0 10px;
   font-weight: 600;
 }
-header nav span {
+header nav span,
+footer span {
   position: relative;
 }
-header nav span .ion-ios-arrow-down {
+span i[class*="ion-ios-arrow-"] {
   margin-left: 8px;
   font-size: 12px;
 }
-header nav span:hover div.drop-menu,
-header nav span:focus div.drop-menu {
+span:hover div.drop-menu,
+span:focus div.drop-menu {
   visibility: visible;
   opacity: 1;
 }
-header nav span div.drop-menu {
+span div.drop-menu {
   opacity: 0;
   visibility: hidden;
 
@@ -205,8 +206,8 @@ header nav span div.drop-menu {
   box-shadow: 0 3px 8px rgba(30, 38, 36, .12);
   transition: all 0.2s ease;
 }
-header nav span div.drop-menu span,
-header nav span div.drop-menu a {
+span div.drop-menu span,
+span div.drop-menu a {
   padding: 10px 15px;
   display: block;
   height: auto;
@@ -219,6 +220,16 @@ footer {
   padding: 0 30px;
   text-align: right;
   color: #869095;
+}
+footer span {
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+}
+footer span div.drop-menu {
+  top: auto;
+  bottom: 40px;
+  box-shadow: 0 3px 3px rgba(30, 38, 36, .05);
 }
 
 .container {

--- a/src/core/templates/css/styles.css
+++ b/src/core/templates/css/styles.css
@@ -187,7 +187,8 @@ span i[class*="ion-ios-arrow-"] {
   font-size: 12px;
 }
 span:hover div.drop-menu,
-span:focus div.drop-menu {
+span:focus div.drop-menu,
+span div.drop-menu.focused {
   visibility: visible;
   opacity: 1;
 }

--- a/src/core/templates/html.html
+++ b/src/core/templates/html.html
@@ -27,13 +27,16 @@
       {{ content }}
     </main>
 
-    <button class="sidebar-control" onclick="toggleSidebar()"><i class="icon ion-md-menu"></i></button>
+    <button class="sidebar-control" aria-label="Toggle sidebar" onclick="toggleSidebar()">
+      <i class="icon ion-md-menu"></i>
+    </button>
   </div>
   {{ body }}
 
   <footer>
     {{ footer }}
   </footer>
+  {{ scripts }}
   <!-- browsersync -->
 </body>
 </html>

--- a/src/core/templates/js/scripts.js
+++ b/src/core/templates/js/scripts.js
@@ -4,6 +4,11 @@ function toggleSidebar() {
   sidebar.classList.toggle('sidebar-active');
 }
 
+function toggleFocus() {
+  const classList = this.parentElement.classList;
+  classList.toggle('focused');
+}
+
 function toggleDark(ele) {
   document.body.classList.toggle('dark');
   
@@ -39,5 +44,20 @@ function toggleDark(ele) {
     button.innerHTML = '<i class="icon ion-ios-sunny"></i>';
   else
     button.innerHTML = '<i class="icon ion-ios-moon"></i>';
+
+})();
+
+/**
+ * Keep drop down menu visible when focussing the menu items
+ */
+(function() {
+  const menus = document.querySelectorAll('span div.drop-menu');
+
+  for (const menu of menus) {
+    for (const child of menu.children) {
+      child.addEventListener('focus', toggleFocus);
+      child.addEventListener('blur', toggleFocus);
+    }
+  }
 
 })();


### PR DESCRIPTION
Proper support for drop menus has been added which follows the improved syntax for creating the navigation.
- Drop menus can be only **1 layer deep**. (Sub drop menu in drop menu is not supported)
- **Drop-down** menus are implemented for header navigation.
- **Drop-up** menus are implemented for the footer.
- Compatible with the **dark theme**.
- Good **accessibility** support.

Points to consider:
- A proper **responsive navigation** layout should be created for mobile devices. This will be implemented through a separate PR.

Closes #9 
Closes #10 