### PR TITLE
DocBook rename to Pencil

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-  <img src="https://docbook.netlify.com/img/logo.svg" alt="DocBook">
+  <img src="https://penciljs.netlify.com/img/logo.svg" alt="Pencil">
 </p>
 
 <p align="center">
-  Docbook is a powerful <b>static documentation website generator</b> that works on <b>Markdown</b>.
+  Pencil is a powerful <b>static documentation website generator</b> that works on <b>Markdown</b>.
 </p>
 
 <p align="center">
@@ -16,9 +16,9 @@
 </p>
 
 ## What can it do?
-DocBook allows you to write content in [Markdown](https://en.wikipedia.org/wiki/Markdown), which has a very **powerful** and **easy** to learn markup syntax. You can quickly start creating your website without much code.
+Pencil allows you to write content in [Markdown](https://en.wikipedia.org/wiki/Markdown), which has a very **powerful** and **easy** to learn markup syntax. You can quickly start creating your website without much code.
 
-DocBook will automatically create the required files for your website, which are **ready to be deployed** to services like Netlify, GitHub Pages.
+Pencil will automatically create the required files for your website, which are **ready to be deployed** to services like Netlify, GitHub Pages.
 
 
 ## Features
@@ -41,21 +41,21 @@ DocBook will automatically create the required files for your website, which are
 - Custom plugins support
 
 ## Quick start
-DocBook site can be created quickly using the CLI tool. Make sure you have recent LTS version of [Node.js](https://nodejs.org/) installed. Follow the commands below:
+Pencil site can be created quickly using the CLI tool. Make sure you have recent LTS version of [Node.js](https://nodejs.org/) installed. Follow the commands below:
 ```bash
-npm install -g docbook
-docbook init
+npm install -g @pencil/core
+pencil init
 # follow steps shown in CLI
 ```
 > Installing dependencies via `npm install` is not necessary if CLI is globally installed.
 
 
 ## Development
-Following commands must be followed to setup DocBook development environment.
+Following commands must be followed to setup Pencil development environment.
 
 ```bash
-git clone https://github.com/blenderskool/docbook
-cd docbook
+git clone https://github.com/blenderskool/pencil
+cd pencil
 npm install
 npm run dev
 ```
@@ -63,13 +63,13 @@ By default, the dev server opens at port `3000` with the playground.
 Playground is where you can test the code and make live changes to it.
 
 ### Directory structure
-DocBook follows the following directory structure,
+Pencil follows the following directory structure,
 - `src` - Contains the source code.
   - `core` - Core modules that are used.
     - `functions` - Contains the code for the builder.
     - `templates` - Template files that define the structure, design and basic functionality of documentation website.
     - `utils` - Helper functions used extensively in functions.
-- `playground` - A sample documentation website setup to test DocBook features during development.
+- `playground` - A sample documentation website setup to test Pencil features during development.
 - `bin` - Contains the scripts for the CLI.
 
 ## Contributing
@@ -93,4 +93,4 @@ git push origin some-fix
 Once you are done with the changes, you can open a pull request to `dev` branch.
 
 ## License
-DocBook is [MIT Licensed](https://github.com/blenderskool/docbook/blob/master/LICENSE)
+Pencil is [MIT Licensed](https://github.com/blenderskool/pencil/blob/master/LICENSE)

--- a/bin/pencil
+++ b/bin/pencil
@@ -17,9 +17,9 @@ program
 program
   .command('init')
   .alias('i')
-  .description('Start a new DocBook project')
+  .description('Start a new Pencil project')
   .action(() => {
-    require('./docbook-init');
+    require('./pencil-init');
   });
 
 /**
@@ -34,7 +34,7 @@ program
     
     log(chalk.blue.bold('Starting local server on port '+cmd.port));
 
-    const dev = require('./docbook-dev');
+    const dev = require('./pencil-dev');
     dev(cmd.port);
   });
 
@@ -68,7 +68,7 @@ program
 program
   .on('command:*', () => {
     log(chalk.red.bold('Invalid command'));
-    log(chalk.blue.bold('Use') + ' docbook --help' + chalk.blue.bold(' to view valid commands'));
+    log(chalk.blue.bold('Use') + ' pencil --help' + chalk.blue.bold(' to view valid commands'));
     log();
   });
 

--- a/bin/pencil-dev
+++ b/bin/pencil-dev
@@ -49,7 +49,7 @@ module.exports = function dev(port) {
      * Check if the config file is syntactically correct before rebuild
      */
     try {
-      const script = vm.runInNewContext('require(join(process.cwd(), "docbook.config"))', {require, join, process});
+      const script = vm.runInNewContext('require(join(process.cwd(), "pencil.config"))', {require, join, process});
     }
     catch(e) {
       console.log(chalk.red(e.stack));

--- a/bin/pencil-init
+++ b/bin/pencil-init
@@ -40,7 +40,7 @@ const log = console.log;
        * Download the site template from GitHub
        */
       log(chalk.blue.bold('\nDownloading template\n'));
-      download('blenderskool/docbook-template', projPath, err => {
+      download('blenderskool/pencil-template', projPath, err => {
 
         if (err) return log(chalk.red.bold('There was an error'));
 
@@ -57,7 +57,7 @@ const log = console.log;
          */
         log(chalk.green.bold('Download successful! Use these commands to start working on the site\n'));
         log(chalk.gray('cd '+shtName));
-        log(chalk.gray('docbook dev'));
+        log(chalk.gray('pencil dev'));
         log();
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "docbook",
-  "version": "0.7.1",
+  "name": "@pencil/core",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "docbook",
-  "version": "0.7.1",
+  "name": "@pencil/core",
+  "version": "0.8.0",
   "description": "Static documentation website generator based on markdown",
   "main": "build/index.js",
   "scripts": {
@@ -14,16 +14,16 @@
     "prepare": "cd playground && npm install"
   },
   "bin": {
-    "docbook": "bin/docbook"
+    "pencil": "bin/pencil"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/blenderskool/docbook"
+    "url": "git+https://github.com/blenderskool/pencil.git"
   },
   "bugs": {
-    "url": "https://github.com/blenderskool/docbook/issues"
+    "url": "https://github.com/blenderskool/pencil/issues"
   },
-  "homepage": "https://github.com/blenderskool/docbook#readme",
+  "homepage": "https://github.com/blenderskool/pencil#readme",
   "author": "Akash Hamirwasia",
   "license": "MIT",
   "devDependencies": {
@@ -53,5 +53,12 @@
     "rimraf": "^2.6.3",
     "showdown": "^1.8.6",
     "showdown-emoji": "^1.0.5"
-  }
+  },
+  "keywords": [
+    "static",
+    "documentation",
+    "website",
+    "generator",
+    "markdown"
+  ]
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,19 +1,17 @@
 {
   "name": "acme-docs",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "A sandboxed environment to test out new Pencil features",
+  "private": true,
   "scripts": {
-    "dev": "docbook dev",
+    "dev": "pencil dev",
     "start": "npm run dev",
-    "build": "docbook build",
-    "version": "docbook --version"
+    "build": "pencil build",
+    "version": "pencil --version"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
-    "docbook": "../"
+    "pencil": "../"
   },
   "random": "file:../"
 }

--- a/playground/pencil.config.js
+++ b/playground/pencil.config.js
@@ -1,17 +1,17 @@
 module.exports = {
   head: {
-    title: 'DocBook playground'
+    title: 'Pencil playground'
   },
   navigation: [
-    ['Docbook API', {
+    ['Pencil API :computer:', {
       newTab: true,
-      link: 'https://docbook.netlify.com/config/'
+      link: 'https://penciljs.netlify.com/config/'
     }]
   ],
   darkTheme: {
     toggle: true
   },
-  logo: 'https://docbook.netlify.com/img/logo.svg',
+  logo: 'https://penciljs.netlify.com/img/logo.svg',
   themeColor: '#287be1',
   plugins: {
     callout: 'plugins/callout.js',
@@ -22,13 +22,17 @@ module.exports = {
     ['Introduction', '/'],
     ['Sample section', {
       'Sample page': '/sample'
+    }],
+    ['icon', {
+      value: 'github',
+      type: 'logo',
     }]
   ],
   footer: [
     ['<icon type="logo">github</icon>', {
-      link: 'https://github.com/blenderskool/docbook',
+      link: 'https://github.com/blenderskool/pencil',
       newTab: true
     }],
-    'Made using DocBook'
+    'Made using Pencil :tada:'
   ]
 }

--- a/playground/src/index.md
+++ b/playground/src/index.md
@@ -1,5 +1,5 @@
 # Playground
-**Welcome to the DocBook Playground.** This is the place where you can test out DocBook features that you are developing :smiley:
+**Welcome to the Pencil Playground.** This is the place where you can test out Pencil features that you are developing :smiley:
 
 <callout type="success">
   Remove code in `playground/index.md`**(this page)** and start playing!

--- a/src/core/functions/templates/html/index.js
+++ b/src/core/functions/templates/html/index.js
@@ -86,8 +86,8 @@ export default function(frontMatter) {
     template = template.loadHook('title', config.head ?
     config.head.title ?
     config.head.title :
-    'DocBook site' :
-    'DocBook site');
+    'Pencil site' :
+    'Pencil site');
 
   /**
    * Adds the theme-color meta tag based on following order
@@ -159,7 +159,7 @@ export default function(frontMatter) {
       `<header>${config.logo ?
       `<a href="/" class="brand"><img alt="${config.head ?
       config.head.title :
-      'Docbook site'}" src=${config.logo}></a>` :
+      'Pencil site'}" src=${config.logo}></a>` :
       ''}<nav>{{ nav }}</nav></header>`
     );
     // Adds a class to the container to accomodate for the fixed header height

--- a/src/core/templates/js/scripts.js
+++ b/src/core/templates/js/scripts.js
@@ -21,7 +21,7 @@ function toggleDark(ele) {
   /**
    * Store this in local storage
    */
-  localStorage.setItem('docbook-data', JSON.stringify({
+  localStorage.setItem('pencil-data', JSON.stringify({
     darkTheme: document.body.classList.contains('dark')
   }));
 }
@@ -30,7 +30,7 @@ function toggleDark(ele) {
  * Use the local storage data on page load
  */
 (function() {
-  const data = JSON.parse(localStorage.getItem('docbook-data'));
+  const data = JSON.parse(localStorage.getItem('pencil-data'));
   const button = document.querySelector('button.theme-toggle');
 
   if (data) {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default function(options) {
      * Global read only variables are set here
      */
     global.__base = basePath;
-    global.__config = path.join(__base, 'docbook.config');
+    global.__config = path.join(__base, 'pencil.config');
     global.__deploy = deployPath;
 
     /**


### PR DESCRIPTION
## The same DocBook now under a new name! Say hello to Pencil :tada: 

<p align="center">
  <img src="https://user-images.githubusercontent.com/21107799/52206182-6f13f200-289f-11e9-82f6-903e505a0274.png" alt="Pencil">
</p>

DocBook has been renamed to Pencil for the following reasons:
 - **Name conflict** with DocBook schema by OASIS. Thanks to @grahamc for pointing out, this was one of the main reasons for the new name.
 - **Project capabilities** - While DocBook was built mainly for creating documentation, it was never limited to just creating documentation. With a new name, Pencil would fill in those gaps which would allow it to be used for a variety of sites.

### What future holds?
The last version published under the name DocBook was `0.7.1`. Pencil would pick up from here and continue its development. **The npm package located [here](https://www.npmjs.com/package/docbook) would now be deprecated** to prevent upgrade issues. Pencil would now be published under the name of `@pencil/core` via npm.

All CLI commands, file configs would be updated to include `pencil` instead of `docbook` in their name.